### PR TITLE
Ensure uploads directory exists automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+uploads/

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ npm run db:push
 
 ### File Upload Errors
 - Check file path handling in routes.ts
-- Ensure uploads/ directory exists
+- `uploads/` directory is created automatically if missing
 - Verify file type validation
 
 ### AI Processing Errors

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,14 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import fs from "fs";
 
 const app = express();
+
+// Ensure the uploads directory exists so multer can save files
+if (!fs.existsSync("uploads")) {
+  fs.mkdirSync("uploads", { recursive: true });
+}
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 


### PR DESCRIPTION
## Summary
- create `uploads/` directory at server startup if it's missing
- ignore the uploads directory in git
- document automatic creation of `uploads/` in README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684a854f6860832f845f1416f7c9411f